### PR TITLE
chore: use flyway for migrations in tests

### DIFF
--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/api/AbstractApiTestContainer.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/api/AbstractApiTestContainer.java
@@ -37,7 +37,7 @@ public class AbstractApiTestContainer<SELF extends GenericContainer<SELF>>
               container.start();
               if (container instanceof PostgresTestContainer) {
                 PostgresTestContainer postgresTestContainer = (PostgresTestContainer) container;
-                postgresTestContainer.applyMigrations(api.migrations());
+                postgresTestContainer.applyFlywayMigrations(api.migrations());
                 withEnv("POSTGRES_HOST", PostgresTestContainer.NETWORK_ALIAS);
               }
             });

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/api/Api.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/api/Api.java
@@ -31,7 +31,7 @@ public enum Api {
   }
 
   public Path migrations() {
-    return ProjectUtils.getFromBackend(name().toLowerCase(), fullName(), "migrations", "sql");
+    return ProjectUtils.getFromBackend(name().toLowerCase(), fullName(), "migrations");
   }
 
   public String fullName() {

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresFlywayTestContainer.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresFlywayTestContainer.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 @Slf4j
@@ -15,6 +16,8 @@ public class PostgresFlywayTestContainer<SELF extends PostgresFlywayTestContaine
     super(new ImageFromDockerfile().withFileFromPath(".", migrationsFolderPath));
     withNetwork(Network.SHARED)
         .withEnv("POSTGRES_HOST", PostgresTestContainer.NETWORK_ALIAS)
-        .withLogConsumer(new Slf4jLogConsumer(log));
+        .withLogConsumer(new Slf4jLogConsumer(log))
+        .waitingFor(
+            Wait.forLogMessage("^Successfully applied (.*) migration to schema \"(.*)\".*$", 1));
   }
 }

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresFlywayTestContainer.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/testconainers/pg/PostgresFlywayTestContainer.java
@@ -1,0 +1,20 @@
+package com.meemaw.test.testconainers.pg;
+
+import java.nio.file.Path;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+@Slf4j
+public class PostgresFlywayTestContainer<SELF extends PostgresFlywayTestContainer<SELF>>
+    extends GenericContainer<SELF> {
+
+  public PostgresFlywayTestContainer(Path migrationsFolderPath) {
+    super(new ImageFromDockerfile().withFileFromPath(".", migrationsFolderPath));
+    withNetwork(Network.SHARED)
+        .withEnv("POSTGRES_HOST", PostgresTestContainer.NETWORK_ALIAS)
+        .withLogConsumer(new Slf4jLogConsumer(log));
+  }
+}


### PR DESCRIPTION
We use Flyway to run migrations in "prod" but we did not use it in our integration test suite. Since upgrade of `testconainers` we can nicely use `ImageFromDockerfile` extension and run migrations with flyway in our tests setup.


Before we were reading all filed in the directory containing migrations and apply them one by one.