### PR TITLE
chore: tracing improvements

### DIFF
--- a/.github/workflows/frontend:try.yml
+++ b/.github/workflows/frontend:try.yml
@@ -83,8 +83,8 @@ jobs:
       - name: frontend/try | start
         run: |
           yarn workspace @insight/try start -p 3002 2>&1 | tee $ARTIFACTS_PATH/serve.log &
-          node_modules/wait-on/bin/wait-on http-get://localhost:3002 --timeout 60000
-          node_modules/wait-on/bin/wait-on http-get://localhost:8080/health/ready --timeout 60000
+          node_modules/wait-on/bin/wait-on http-get://localhost:3002 --timeout 180000
+          node_modules/wait-on/bin/wait-on http-get://localhost:8080/health/ready --timeout 180000
       - name: frontend/try | test:e2e
         run: |
           mkdir -p $ARTIFACTS_PATH/screenshots

--- a/backend/session/session-api/src/main/java/com/meemaw/session/service/PageService.java
+++ b/backend/session/session-api/src/main/java/com/meemaw/session/service/PageService.java
@@ -13,6 +13,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.metrics.annotation.Timed;
+import org.eclipse.microprofile.opentracing.Traced;
 import org.slf4j.MDC;
 
 @ApplicationScoped
@@ -37,6 +38,7 @@ public class PageService {
    * @return PageIdentity
    */
   @Timed(name = "createPage", description = "A measure of how long it takes to create a page")
+  @Traced
   public Uni<PageIdentity> createPage(CreatePageDTO page, String userAgent, String ipAddress) {
     UUID pageId = UUID.randomUUID();
     UUID deviceId = Optional.ofNullable(page.getDeviceId()).orElseGet(UUID::randomUUID);

--- a/backend/shared/rest-api/src/main/java/com/meemaw/shared/rest/filter/RequestLoggingFilter.java
+++ b/backend/shared/rest-api/src/main/java/com/meemaw/shared/rest/filter/RequestLoggingFilter.java
@@ -4,7 +4,6 @@ import static javax.ws.rs.core.Response.Status.Family.CLIENT_ERROR;
 import static javax.ws.rs.core.Response.Status.Family.SERVER_ERROR;
 
 import com.meemaw.shared.metrics.MetricsService;
-import io.opentracing.Tracer;
 import io.vertx.core.http.HttpServerRequest;
 import java.util.UUID;
 import javax.annotation.Priority;
@@ -30,7 +29,7 @@ public class RequestLoggingFilter implements ContainerRequestFilter, ContainerRe
   private static final String LOG_START_TIME_PROPERTY = "start-time";
   private static final long REQUEST_LATENCY_LOG_LIMIT_MS = 50;
 
-  @Inject Tracer tracer;
+  // @Inject Tracer tracer;
   @Inject MetricsService metricsService;
   @Context UriInfo info;
   @Context HttpServerRequest request;
@@ -93,7 +92,7 @@ public class RequestLoggingFilter implements ContainerRequestFilter, ContainerRe
       return;
     }
 
-    tracer.activeSpan().setTag(REQUEST_ID_HEADER, requestId);
+    // tracer.activeSpan().setTag(REQUEST_ID_HEADER, requestId);
     long timeElapsed = System.currentTimeMillis() - startTime;
     if (timeElapsed > REQUEST_LATENCY_LOG_LIMIT_MS) {
       log.info("Request processing latency: {}ms", timeElapsed);

--- a/backend/shared/rest/src/main/java/com/meemaw/shared/logging/LoggingConstants.java
+++ b/backend/shared/rest/src/main/java/com/meemaw/shared/logging/LoggingConstants.java
@@ -2,6 +2,10 @@ package com.meemaw.shared.logging;
 
 public final class LoggingConstants {
 
+  /* General */
+  public static final String LOG_LINK = "log.link";
+  public static final String TRACE_LINK = "trace.link";
+
   /* SSO */
   public static final String COOKIE_SESSION_ID = "cookie.session.id";
 

--- a/frontend/browser/tracking/src/index.spec.ts
+++ b/frontend/browser/tracking/src/index.spec.ts
@@ -53,7 +53,7 @@ describe('tracking script', () => {
   let server: Server;
 
   beforeAll(() => {
-    jest.setTimeout(60000);
+    jest.setTimeout(180000);
     const pagePath = path.join(process.cwd(), 'templates', 'index.html');
     const pageContents = String(fs.readFileSync(pagePath));
     server = createServer((_req, res) => {


### PR DESCRIPTION
For easier debugging:
- Include `X-Request-Id` header in HTTP responses
- Include `X-Request-Id` in traces

One can send us a problematic HTTP `X-Request-Id` and we can easily search our logs/traces with it.