### PR TITLE
feat(auth): logout from all devices

### DIFF
--- a/backend/auth/auth-api-contracts/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResource.java
+++ b/backend/auth/auth-api-contracts/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResource.java
@@ -36,6 +36,11 @@ public interface SsoResource {
   CompletionStage<Response> logout(
       @NotBlank(message = "Required") @CookieParam(SsoSession.COOKIE_NAME) String sessionId);
 
+  @POST
+  @Path("logout-from-all-devices")
+  CompletionStage<Response> logoutFromAllDevices(
+      @NotBlank(message = "Required") @CookieParam(SsoSession.COOKIE_NAME) String sessionId);
+
   @GET
   @Path("session")
   @Produces(MediaType.APPLICATION_JSON)

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/organization/invite/model/TeamInvite.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/organization/invite/model/TeamInvite.java
@@ -1,6 +1,6 @@
 package com.meemaw.auth.organization.invite.model;
 
-import com.meemaw.auth.shared.CanExpire;
+import com.meemaw.shared.model.CanExpire;
 import com.meemaw.auth.user.model.UserRole;
 import java.time.OffsetDateTime;
 import java.util.UUID;

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/password/model/PasswordResetRequest.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/password/model/PasswordResetRequest.java
@@ -1,6 +1,6 @@
 package com.meemaw.auth.password.model;
 
-import com.meemaw.auth.shared.CanExpire;
+import com.meemaw.shared.model.CanExpire;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import lombok.Value;

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/signup/model/SignUpRequest.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/signup/model/SignUpRequest.java
@@ -1,6 +1,6 @@
 package com.meemaw.auth.signup.model;
 
-import com.meemaw.auth.shared.CanExpire;
+import com.meemaw.shared.model.CanExpire;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/datasource/HazelcastSsoDatasource.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/datasource/HazelcastSsoDatasource.java
@@ -1,63 +1,97 @@
 package com.meemaw.auth.sso.datasource;
 
+import com.hazelcast.map.EntryProcessor;
 import com.hazelcast.map.IMap;
 import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.model.AuthUser;
+import io.smallrye.mutiny.Uni;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.opentracing.Traced;
 
 @ApplicationScoped
 @Slf4j
 public class HazelcastSsoDatasource implements SsoDatasource {
 
-  private static final String SESSION_MAP_NAME = "auth.auth.session";
+  private IMap<String, SsoUser> sessionToUserMap;
+  private IMap<UUID, List<String>> userToSessionsMap;
 
   @Inject HazelcastProvider hazelcastProvider;
 
-  private IMap<String, SsoUser> sessions;
+  @ConfigProperty(name = "hazelcast.auth.session-to-user-map")
+  String sessionToUserMapName;
+
+  @ConfigProperty(name = "hazelcast.auth.user-to-sessions-map")
+  String userToSessionsMapName;
 
   @PostConstruct
   public void init() {
-    log.info("Initializing HazelcastSsoDatasource IMap={}", SESSION_MAP_NAME);
-    sessions = hazelcastProvider.getInstance().getMap(SESSION_MAP_NAME);
+    log.info(
+        "Initializing HazelcastSsoDatasource sessionToUserMap: {} userToSessionsMap: {}",
+        sessionToUserMapName,
+        userToSessionsMapName);
+
+    sessionToUserMap = hazelcastProvider.getInstance().getMap(sessionToUserMapName);
+    userToSessionsMap = hazelcastProvider.getInstance().getMap(userToSessionsMapName);
   }
 
   @Override
   @Traced
   public CompletionStage<String> createSession(AuthUser user) {
     String sessionId = SsoSession.newIdentifier();
-    return sessions
-        .setAsync(
+
+    CompletionStage<Void> sessionToUserLookup =
+        sessionToUserMap.setAsync(
             sessionId,
             SsoUser.as(user),
             SsoSession.TTL,
             TimeUnit.SECONDS,
             SsoSession.MAX_IDLE,
-            TimeUnit.SECONDS)
-        .thenApply(
-            x -> {
-              log.info("Session id={} created for userId={}", sessionId, user.getId());
-              return sessionId;
-            });
+            TimeUnit.SECONDS);
+
+    CompletionStage<Void> userToSessionsLookup =
+        userToSessionsMap.submitToKey(
+            user.getId(),
+            (EntryProcessor<UUID, List<String>, Void>)
+                entry -> {
+                  List<String> sessionIds =
+                      Optional.ofNullable(entry.getValue()).orElseGet(ArrayList::new);
+                  sessionIds.add(sessionId);
+                  entry.setValue(sessionIds);
+                  return null;
+                });
+
+    return Uni.combine()
+        .all()
+        .unis(
+            Uni.createFrom().completionStage(sessionToUserLookup),
+            Uni.createFrom().completionStage(userToSessionsLookup))
+        .combinedWith(ignored -> sessionId)
+        .subscribeAsCompletionStage();
   }
 
   @Override
   @Traced
   public CompletionStage<Optional<SsoUser>> findSession(String sessionId) {
-    return sessions.getAsync(sessionId).thenApply(Optional::ofNullable);
+    return sessionToUserMap.getAsync(sessionId).thenApply(Optional::ofNullable);
   }
 
   @Override
   @Traced
   public CompletionStage<Optional<SsoUser>> deleteSession(String sessionId) {
-    return sessions
+    return sessionToUserMap
         .removeAsync(sessionId)
         .thenApply(
             ssoUser -> {
@@ -67,5 +101,22 @@ public class HazelcastSsoDatasource implements SsoDatasource {
               log.info("Session id={} deleted for userId={}", sessionId, ssoUser.getId());
               return Optional.of(ssoUser);
             });
+  }
+
+  @Override
+  @Traced
+  public CompletionStage<List<String>> deleteAllSessionsForUser(UUID userId) {
+    List<String> sessions =
+        Optional.ofNullable(userToSessionsMap.get(userId)).orElseGet(Collections::emptyList);
+
+    return sessionToUserMap
+        .submitToKeys(
+            new HashSet<>(sessions),
+            (EntryProcessor<String, SsoUser, SsoUser>)
+                entry -> {
+                  entry.setValue(null);
+                  return null;
+                })
+        .thenApply(ignored -> sessions);
   }
 }

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/datasource/SsoDatasource.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/datasource/SsoDatasource.java
@@ -2,7 +2,9 @@ package com.meemaw.auth.sso.datasource;
 
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.model.AuthUser;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
 public interface SsoDatasource {
@@ -30,4 +32,12 @@ public interface SsoDatasource {
    * @return maybe user associated with the session if the session exists
    */
   CompletionStage<Optional<SsoUser>> deleteSession(String sessionId);
+
+  /**
+   * Delete all SSO sessions for a given user id.
+   *
+   * @param userId user id
+   * @return list of deleted sessions
+   */
+  CompletionStage<List<String>> deleteAllSessionsForUser(UUID userId);
 }

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/datasource/SsoDatasource.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/datasource/SsoDatasource.java
@@ -2,7 +2,7 @@ package com.meemaw.auth.sso.datasource;
 
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.model.AuthUser;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
@@ -37,7 +37,7 @@ public interface SsoDatasource {
    * Delete all SSO sessions for a given user id.
    *
    * @param userId user id
-   * @return list of deleted sessions
+   * @return collection of deleted sessions
    */
-  CompletionStage<List<String>> deleteAllSessionsForUser(UUID userId);
+  CompletionStage<Collection<String>> deleteAllSessionsForUser(UUID userId);
 }

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResourceImpl.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/resource/v1/SsoResourceImpl.java
@@ -45,10 +45,20 @@ public class SsoResourceImpl implements SsoResource {
               ResponseBuilder builder =
                   maybeUser.isPresent()
                       ? Response.noContent()
-                      : DataResponse.error(Boom.badRequest().message("Session does not exist"))
-                          .builder();
+                      : DataResponse.error(Boom.notFound()).builder();
               return builder.cookie(SsoSession.clearCookie(cookieDomain)).build();
             });
+  }
+
+  @Override
+  public CompletionStage<Response> logoutFromAllDevices(String sessionId) {
+    MDC.put(LoggingConstants.COOKIE_SESSION_ID, sessionId);
+    log.debug("Logout from all devices request");
+    String cookieDomain = RequestUtils.parseCookieDomain(request.absoluteURI());
+    return ssoService
+        .logoutFromAllDevices(sessionId)
+        .thenApply(
+            sessions -> Response.noContent().cookie(SsoSession.clearCookie(cookieDomain)).build());
   }
 
   @Override

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoHazelcastService.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoHazelcastService.java
@@ -6,7 +6,9 @@ import com.meemaw.auth.sso.datasource.SsoDatasource;
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.datasource.UserDatasource;
 import com.meemaw.auth.user.model.AuthUser;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.enterprise.context.ApplicationScoped;
@@ -45,6 +47,15 @@ public class SsoHazelcastService implements SsoService {
   @Timed(name = "logout", description = "A measure of how long it takes to do logout")
   public CompletionStage<Optional<SsoUser>> logout(String sessionId) {
     return ssoDatasource.deleteSession(sessionId);
+  }
+
+  @Override
+  @Traced
+  @Timed(
+      name = "logoutFromAllDevices",
+      description = "A measure of how long it takes to do a logout from all devices")
+  public CompletionStage<List<String>> logoutUserFromAllDevices(UUID userId) {
+    return ssoDatasource.deleteAllSessionsForUser(userId);
   }
 
   @Override

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoHazelcastService.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoHazelcastService.java
@@ -6,7 +6,7 @@ import com.meemaw.auth.sso.datasource.SsoDatasource;
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.datasource.UserDatasource;
 import com.meemaw.auth.user.model.AuthUser;
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -54,7 +54,7 @@ public class SsoHazelcastService implements SsoService {
   @Timed(
       name = "logoutFromAllDevices",
       description = "A measure of how long it takes to do a logout from all devices")
-  public CompletionStage<List<String>> logoutUserFromAllDevices(UUID userId) {
+  public CompletionStage<Collection<String>> logoutUserFromAllDevices(UUID userId) {
     return ssoDatasource.deleteAllSessionsForUser(userId);
   }
 

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoService.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoService.java
@@ -2,8 +2,8 @@ package com.meemaw.auth.sso.service;
 
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.model.AuthUser;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -41,7 +41,7 @@ public interface SsoService {
    * @param userId user id
    * @return list of sessions that has been revoked
    */
-  CompletionStage<List<String>> logoutUserFromAllDevices(UUID userId);
+  CompletionStage<Collection<String>> logoutUserFromAllDevices(UUID userId);
 
   /**
    * Logout user associated with a session id from all devices.
@@ -49,12 +49,12 @@ public interface SsoService {
    * @param sessionId session id
    * @return list of sessions that has been revoked
    */
-  default CompletionStage<List<String>> logoutFromAllDevices(String sessionId) {
+  default CompletionStage<Collection<String>> logoutFromAllDevices(String sessionId) {
     return findSession(sessionId)
         .thenCompose(
             maybeUser ->
                 maybeUser.isEmpty()
-                    ? CompletableFuture.completedStage(Collections.emptyList())
+                    ? CompletableFuture.completedStage(Collections.emptySet())
                     : logoutUserFromAllDevices(maybeUser.get().getId()));
   }
 

--- a/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoService.java
+++ b/backend/auth/auth-api/src/main/java/com/meemaw/auth/sso/service/SsoService.java
@@ -2,7 +2,11 @@ package com.meemaw.auth.sso.service;
 
 import com.meemaw.auth.sso.model.SsoUser;
 import com.meemaw.auth.user.model.AuthUser;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public interface SsoService {
@@ -30,6 +34,29 @@ public interface SsoService {
    * @return maybe user associated with logout if it was successful.
    */
   CompletionStage<Optional<SsoUser>> logout(String sessionId);
+
+  /**
+   * Logout user from all devices.
+   *
+   * @param userId user id
+   * @return list of sessions that has been revoked
+   */
+  CompletionStage<List<String>> logoutUserFromAllDevices(UUID userId);
+
+  /**
+   * Logout user associated with a session id from all devices.
+   *
+   * @param sessionId session id
+   * @return list of sessions that has been revoked
+   */
+  default CompletionStage<List<String>> logoutFromAllDevices(String sessionId) {
+    return findSession(sessionId)
+        .thenCompose(
+            maybeUser ->
+                maybeUser.isEmpty()
+                    ? CompletableFuture.completedStage(Collections.emptyList())
+                    : logoutUserFromAllDevices(maybeUser.get().getId()));
+  }
 
   /**
    * Log user associated with the provided credentials in.

--- a/backend/auth/auth-api/src/main/resources/application.properties
+++ b/backend/auth/auth-api/src/main/resources/application.properties
@@ -15,6 +15,10 @@ quarkus.datasource.username=${POSTGRES_USER:postgres}
 quarkus.datasource.password=${POSTGRES_PASSWORD:postgres}
 quarkus.datasource.url=vertx-reactive:postgresql://${POSTGRES_HOST:localhost}/${POSTGRES_DB:postgres}
 
+## Hazelcast configuration
+hazelcast.auth.session-to-user-map=${HAZELCAST_AUTH_SESSION_TO_USER_MAP:auth.session-to-user-map}
+hazelcast.auth.user-to-sessions-map=${HAZELCAST_AUTH_USER_TO_SESSIONS_MAP:auth.user-to-sessions-map}
+
 ## Logging configuration
 quarkus.log.level=${LOG_LEVEL:INFO}
 quarkus.log.console.json=${LOG_JSON:false}

--- a/backend/auth/auth-api/src/test/java/com/meemaw/auth/organization/invite/resource/v1/TeamInviteResourceImplTest.java
+++ b/backend/auth/auth-api/src/test/java/com/meemaw/auth/organization/invite/resource/v1/TeamInviteResourceImplTest.java
@@ -1,6 +1,7 @@
 package com.meemaw.auth.organization.invite.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
+import static com.meemaw.test.setup.SsoTestSetupUtils.signUpAndLogin;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,7 +13,6 @@ import com.meemaw.auth.organization.invite.model.dto.InviteAcceptDTO;
 import com.meemaw.auth.organization.invite.model.dto.InviteCreateDTO;
 import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.auth.user.model.UserRole;
-import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.pg.PostgresTestResource;
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.MockMailbox;
@@ -61,7 +61,7 @@ public class TeamInviteResourceImplTest {
     if (sessionId == null) {
       String email = "org_invite_test@gmail.com";
       String password = "org_invite_test_password";
-      sessionId = SsoTestSetupUtils.signUpAndLogin(mailbox, objectMapper, email, password);
+      sessionId = signUpAndLogin(mailbox, objectMapper, email, password);
     }
 
     return sessionId;
@@ -229,7 +229,7 @@ public class TeamInviteResourceImplTest {
   @Test
   public void list_invites_should_return_collection() throws IOException {
     String sessionId =
-        SsoTestSetupUtils.signUpAndLogin(
+        signUpAndLogin(
             mailbox, objectMapper, "list-invites-fetcher@gmail.com", "list-invites-fetcher");
 
     given()

--- a/backend/auth/auth-api/src/test/java/com/meemaw/auth/password/resource/v1/PasswordResourceImplTest.java
+++ b/backend/auth/auth-api/src/test/java/com/meemaw/auth/password/resource/v1/PasswordResourceImplTest.java
@@ -1,6 +1,7 @@
 package com.meemaw.auth.password.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
+import static com.meemaw.test.setup.SsoTestSetupUtils.signUpAndLogin;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -10,7 +11,6 @@ import com.meemaw.auth.password.model.dto.PasswordForgotRequestDTO;
 import com.meemaw.auth.password.model.dto.PasswordResetRequestDTO;
 import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.auth.sso.resource.v1.SsoResource;
-import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.pg.PostgresTestResource;
 import io.quarkus.mailer.Mail;
 import io.quarkus.mailer.MockMailbox;
@@ -156,7 +156,7 @@ public class PasswordResourceImplTest {
   public void password_forgot_should_send_email_on_existing_user() throws JsonProcessingException {
     String email = "test-forgot-password-flow@gmail.com";
     String password = "superHardPassword";
-    SsoTestSetupUtils.signUpAndLogin(mailbox, objectMapper, email, password);
+    signUpAndLogin(mailbox, objectMapper, email, password);
     PasswordResourceImplTest.passwordForgot(email, objectMapper);
     // can trigger the forgot flow multiple times!!
     PasswordResourceImplTest.passwordForgot(email, objectMapper);
@@ -263,7 +263,7 @@ public class PasswordResourceImplTest {
   public void password_reset_flow_should_succeed_after_sign_up() throws JsonProcessingException {
     String signUpEmail = "reset-password-flow@gmail.com";
     String oldPassword = "superHardPassword";
-    SsoTestSetupUtils.signUpAndLogin(mailbox, objectMapper, signUpEmail, oldPassword);
+    signUpAndLogin(mailbox, objectMapper, signUpEmail, oldPassword);
     PasswordResourceImplTest.passwordForgot(signUpEmail, objectMapper);
 
     // login with "oldPassword" should succeed

--- a/backend/auth/auth-api/src/test/java/com/meemaw/auth/signup/resource/v1/SignUpResourceImplTest.java
+++ b/backend/auth/auth-api/src/test/java/com/meemaw/auth/signup/resource/v1/SignUpResourceImplTest.java
@@ -1,6 +1,8 @@
 package com.meemaw.auth.signup.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
+import static com.meemaw.test.setup.RestAssuredUtils.dontFollowRedirects;
+import static com.meemaw.test.setup.SsoTestSetupUtils.parseLink;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
@@ -10,7 +12,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.meemaw.auth.signup.model.dto.SignUpRequestDTO;
 import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.test.rest.mappers.JacksonMapper;
-import com.meemaw.test.setup.RestAssuredUtils;
 import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.pg.PostgresTestResource;
 import io.quarkus.mailer.Mail;
@@ -142,8 +143,8 @@ public class SignUpResourceImplTest {
     // completing sign up with with referer should redirect back to it
     given()
         .when()
-        .config(RestAssuredUtils.dontFollowRedirects())
-        .get(SsoTestSetupUtils.parseLink(mailbox.getMessagesSentTo(signUpEmail).get(0)))
+        .config(dontFollowRedirects())
+        .get(parseLink(mailbox.getMessagesSentTo(signUpEmail).get(0)))
         .then()
         .statusCode(Status.FOUND.getStatusCode())
         .cookie(SsoSession.COOKIE_NAME)

--- a/backend/auth/auth-api/src/test/java/com/meemaw/auth/sso/resource/v1/SsoResourceImplTest.java
+++ b/backend/auth/auth-api/src/test/java/com/meemaw/auth/sso/resource/v1/SsoResourceImplTest.java
@@ -1,7 +1,9 @@
 package com.meemaw.auth.sso.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
+import static com.meemaw.test.setup.SsoTestSetupUtils.login;
 import static com.meemaw.test.setup.SsoTestSetupUtils.signUpAndLogin;
+import static com.meemaw.test.setup.SsoTestSetupUtils.signUpRequestMock;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -16,7 +18,6 @@ import com.meemaw.auth.user.model.AuthUser;
 import com.meemaw.auth.user.model.UserDTO;
 import com.meemaw.shared.rest.response.DataResponse;
 import com.meemaw.test.rest.mappers.JacksonMapper;
-import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.pg.PostgresTestResource;
 import io.quarkus.mailer.MockMailbox;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -101,7 +102,7 @@ public class SsoResourceImplTest {
   @Test
   public void login_should_fail_when_user_with_unfinished_signUp() throws JsonProcessingException {
     SignUpRequestDTO signUpRequestDTO =
-        SsoTestSetupUtils.signUpRequestMock("login-no-complete@gmail.com", "password123");
+        signUpRequestMock("login-no-complete@gmail.com", "password123");
 
     given()
         .when()
@@ -194,7 +195,7 @@ public class SsoResourceImplTest {
     String password = "test-logout-password";
 
     String firstSessionId = signUpAndLogin(mailbox, objectMapper, email, password);
-    String secondSessionId = SsoTestSetupUtils.login(email, password, null);
+    String secondSessionId = login(email, password);
 
     // Make sure sessions are not the same
     assertNotEquals(firstSessionId, secondSessionId);

--- a/backend/auth/auth-api/src/test/java/com/meemaw/auth/sso/service/google/SsoGoogleServiceImplTest.java
+++ b/backend/auth/auth-api/src/test/java/com/meemaw/auth/sso/service/google/SsoGoogleServiceImplTest.java
@@ -1,0 +1,25 @@
+package com.meemaw.auth.sso.service.google;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.test.junit.QuarkusTest;
+import javax.inject.Inject;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@Tag("integration")
+public class SsoGoogleServiceImplTest {
+
+  @Inject SsoGoogleServiceImpl googleService;
+
+  @Test
+  public void google_service_secure_state_should_be_of_fixed_length() {
+    String data = "data";
+    for (int i = 0; i < 100; i++) {
+      String secureData = googleService.secureState(data);
+      assertEquals(
+          SsoGoogleServiceImpl.SECURE_STATE_PREFIX_LENGTH + data.length(), secureData.length());
+    }
+  }
+}

--- a/backend/beacon/beacon-api/src/main/java/com/meemaw/beacon/model/Beacon.java
+++ b/backend/beacon/beacon-api/src/main/java/com/meemaw/beacon/model/Beacon.java
@@ -14,7 +14,7 @@ public class Beacon {
 
   int timestamp;
   int sequence;
-  List<AbstractBrowserEvent> events;
+  List<AbstractBrowserEvent<?>> events;
 
   Beacon(BeaconDTO dto) {
     this(dto.getTimestamp(), dto.getSequence(), dto.getEvents());

--- a/backend/beacon/beacon-api/src/main/java/com/meemaw/beacon/model/dto/BeaconDTO.java
+++ b/backend/beacon/beacon-api/src/main/java/com/meemaw/beacon/model/dto/BeaconDTO.java
@@ -24,5 +24,5 @@ public class BeaconDTO extends Recorded {
 
   @JsonProperty("e")
   @NotEmpty(message = "e may not be empty")
-  List<AbstractBrowserEvent> events;
+  List<AbstractBrowserEvent<?>> events;
 }

--- a/backend/beacon/beacon-api/src/main/java/com/meemaw/beacon/service/BeaconService.java
+++ b/backend/beacon/beacon-api/src/main/java/com/meemaw/beacon/service/BeaconService.java
@@ -90,7 +90,7 @@ public class BeaconService {
     MDC.put(LoggingConstants.PAGE_ID, pageId.toString());
     MDC.put(LoggingConstants.SESSION_ID, sessionId.toString());
 
-    Function<AbstractBrowserEvent, UserEvent<?>> identify =
+    Function<AbstractBrowserEvent<?>, UserEvent<?>> identify =
         (event) ->
             UserEvent.builder()
                 .event(event)
@@ -110,12 +110,12 @@ public class BeaconService {
               }
               log.info("Sending {} beacon events to Kafka", beacon.getEvents().size());
 
-              List<AbstractBrowserEvent> events = beacon.getEvents();
+              List<AbstractBrowserEvent<?>> events = beacon.getEvents();
               Stream<Uni<Void>> operations =
                   events.stream().map(event -> sendEvent(eventsEmitter, identify, event));
 
               // BrowserUnloadEvent always comes last!
-              AbstractBrowserEvent maybeUnloadEvent = events.get(events.size() - 1);
+              AbstractBrowserEvent<?> maybeUnloadEvent = events.get(events.size() - 1);
               if (maybeUnloadEvent instanceof BrowserUnloadEvent) {
                 log.info("Sending BrowserUnloadEvent to Kafka");
                 operations =
@@ -133,8 +133,8 @@ public class BeaconService {
 
   private Uni<Void> sendEvent(
       Emitter<UserEvent<?>> channel,
-      Function<AbstractBrowserEvent, UserEvent<?>> identify,
-      AbstractBrowserEvent event) {
+      Function<AbstractBrowserEvent<?>, UserEvent<?>> identify,
+      AbstractBrowserEvent<?> event) {
     return Uni.createFrom().completionStage(channel.send(identify.apply(event)));
   }
 }

--- a/backend/session/session-api/src/test/java/com/meemaw/session/events/resource/v1/EventsResourceImplTest.java
+++ b/backend/session/session-api/src/test/java/com/meemaw/session/events/resource/v1/EventsResourceImplTest.java
@@ -2,6 +2,7 @@ package com.meemaw.session.events.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
 import static com.meemaw.test.setup.SsoTestSetupUtils.cookieExpect401;
+import static com.meemaw.test.setup.SsoTestSetupUtils.loginWithInsightAdmin;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
@@ -12,7 +13,6 @@ import com.meemaw.events.model.incoming.AbstractBrowserEvent;
 import com.meemaw.events.model.incoming.UserEvent;
 import com.meemaw.session.resource.v1.SessionResource;
 import com.meemaw.test.rest.mappers.JacksonMapper;
-import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.api.auth.AuthApiTestResource;
 import com.meemaw.test.testconainers.elasticsearch.ElasticsearchTestExtension;
 import com.meemaw.test.testconainers.elasticsearch.ElasticsearchTestResource;
@@ -96,7 +96,7 @@ public class EventsResourceImplTest {
   public void events_search_should_return_empty_list_on_random_session() {
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+        .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
         .get(String.format(SEARCH_EVENTS_PATH_TEMPLATE, UUID.randomUUID()))
         .then()
         .statusCode(200)
@@ -112,7 +112,7 @@ public class EventsResourceImplTest {
             () ->
                 given()
                     .when()
-                    .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+                    .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
                     .get(String.format(SEARCH_EVENTS_PATH_TEMPLATE, SESSION_ID))
                     .then()
                     .statusCode(200)
@@ -129,7 +129,7 @@ public class EventsResourceImplTest {
             () ->
                 given()
                     .when()
-                    .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+                    .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
                     .get(String.format(SEARCH_EVENTS_PATH_TEMPLATE, SESSION_ID) + "?event.e=eq:4")
                     .then()
                     .statusCode(200)

--- a/backend/session/session-api/src/test/java/com/meemaw/session/events/resource/v1/EventsResourceImplTest.java
+++ b/backend/session/session-api/src/test/java/com/meemaw/session/events/resource/v1/EventsResourceImplTest.java
@@ -2,7 +2,6 @@ package com.meemaw.session.events.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
 import static com.meemaw.test.setup.SsoTestSetupUtils.cookieExpect401;
-import static com.meemaw.test.setup.SsoTestSetupUtils.login;
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.is;
@@ -13,6 +12,7 @@ import com.meemaw.events.model.incoming.AbstractBrowserEvent;
 import com.meemaw.events.model.incoming.UserEvent;
 import com.meemaw.session.resource.v1.SessionResource;
 import com.meemaw.test.rest.mappers.JacksonMapper;
+import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.api.auth.AuthApiTestResource;
 import com.meemaw.test.testconainers.elasticsearch.ElasticsearchTestExtension;
 import com.meemaw.test.testconainers.elasticsearch.ElasticsearchTestResource;
@@ -96,7 +96,7 @@ public class EventsResourceImplTest {
   public void events_search_should_return_empty_list_on_random_session() {
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, login())
+        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
         .get(String.format(SEARCH_EVENTS_PATH_TEMPLATE, UUID.randomUUID()))
         .then()
         .statusCode(200)
@@ -112,7 +112,7 @@ public class EventsResourceImplTest {
             () ->
                 given()
                     .when()
-                    .cookie(SsoSession.COOKIE_NAME, login())
+                    .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
                     .get(String.format(SEARCH_EVENTS_PATH_TEMPLATE, SESSION_ID))
                     .then()
                     .statusCode(200)
@@ -129,7 +129,7 @@ public class EventsResourceImplTest {
             () ->
                 given()
                     .when()
-                    .cookie(SsoSession.COOKIE_NAME, login())
+                    .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
                     .get(String.format(SEARCH_EVENTS_PATH_TEMPLATE, SESSION_ID) + "?event.e=eq:4")
                     .then()
                     .statusCode(200)

--- a/backend/session/session-api/src/test/java/com/meemaw/session/resource/v1/SessionResourceTest.java
+++ b/backend/session/session-api/src/test/java/com/meemaw/session/resource/v1/SessionResourceTest.java
@@ -1,5 +1,6 @@
 package com.meemaw.session.resource.v1;
 
+import static com.meemaw.test.setup.SsoTestSetupUtils.loginWithInsightAdmin;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -11,7 +12,6 @@ import com.meemaw.auth.sso.model.SsoSession;
 import com.meemaw.session.model.PageIdentity;
 import com.meemaw.session.model.SessionDTO;
 import com.meemaw.shared.rest.response.DataResponse;
-import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.api.auth.AuthApiTestResource;
 import com.meemaw.test.testconainers.pg.PostgresTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
@@ -66,7 +66,7 @@ public class SessionResourceTest {
     // GET newly created page
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+        .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
         .queryParam("organizationId", "000000") // TODO: remove when S2S auth
         .get(String.format(SESSION_PAGE_PATH_TEMPLATE, sessionId, pageId))
         .then()
@@ -78,7 +78,7 @@ public class SessionResourceTest {
     DataResponse<SessionDTO> sessionDataResponse =
         given()
             .when()
-            .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+            .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
             .get(String.format(SESSION_PATH_TEMPLATE, sessionId))
             .then()
             .statusCode(200)
@@ -92,7 +92,7 @@ public class SessionResourceTest {
     // GET sessions
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+        .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
         .get(
             String.format(
                 "%s?created_at=gte:%s",
@@ -124,7 +124,7 @@ public class SessionResourceTest {
     // GET sessions again to confirm no new sessions has been created
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+        .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
         .get(
             String.format(
                 "%s?created_at=gte:%s",
@@ -177,7 +177,7 @@ public class SessionResourceTest {
     DataResponse<SessionDTO> firstSessionDataResponse =
         given()
             .when()
-            .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+            .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
             .get(String.format(SESSION_PATH_TEMPLATE, sessionId))
             .then()
             .statusCode(200)
@@ -188,7 +188,7 @@ public class SessionResourceTest {
     // GET sessions should return 2 newly created sessions
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
+        .cookie(SsoSession.COOKIE_NAME, loginWithInsightAdmin())
         .get(
             String.format(
                 "%s?created_at=gte:%s",

--- a/backend/session/session-api/src/test/java/com/meemaw/session/resource/v1/SessionResourceTest.java
+++ b/backend/session/session-api/src/test/java/com/meemaw/session/resource/v1/SessionResourceTest.java
@@ -66,7 +66,7 @@ public class SessionResourceTest {
     // GET newly created page
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.login())
+        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
         .queryParam("organizationId", "000000") // TODO: remove when S2S auth
         .get(String.format(SESSION_PAGE_PATH_TEMPLATE, sessionId, pageId))
         .then()
@@ -78,7 +78,7 @@ public class SessionResourceTest {
     DataResponse<SessionDTO> sessionDataResponse =
         given()
             .when()
-            .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.login())
+            .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
             .get(String.format(SESSION_PATH_TEMPLATE, sessionId))
             .then()
             .statusCode(200)
@@ -92,7 +92,7 @@ public class SessionResourceTest {
     // GET sessions
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.login())
+        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
         .get(
             String.format(
                 "%s?created_at=gte:%s",
@@ -124,7 +124,7 @@ public class SessionResourceTest {
     // GET sessions again to confirm no new sessions has been created
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.login())
+        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
         .get(
             String.format(
                 "%s?created_at=gte:%s",
@@ -177,7 +177,7 @@ public class SessionResourceTest {
     DataResponse<SessionDTO> firstSessionDataResponse =
         given()
             .when()
-            .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.login())
+            .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
             .get(String.format(SESSION_PATH_TEMPLATE, sessionId))
             .then()
             .statusCode(200)
@@ -188,7 +188,7 @@ public class SessionResourceTest {
     // GET sessions should return 2 newly created sessions
     given()
         .when()
-        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.login())
+        .cookie(SsoSession.COOKIE_NAME, SsoTestSetupUtils.loginWithInsightAdmin())
         .get(
             String.format(
                 "%s?created_at=gte:%s",

--- a/backend/session/session-api/src/test/java/com/meemaw/session/resource/v1/SessionResourceValidationTest.java
+++ b/backend/session/session-api/src/test/java/com/meemaw/session/resource/v1/SessionResourceValidationTest.java
@@ -1,10 +1,10 @@
 package com.meemaw.session.resource.v1;
 
 import static com.meemaw.test.matchers.SameJSON.sameJson;
+import static com.meemaw.test.setup.SsoTestSetupUtils.cookieExpect401;
 import static io.restassured.RestAssured.given;
 
 import com.meemaw.auth.sso.model.SsoSession;
-import com.meemaw.test.setup.SsoTestSetupUtils;
 import com.meemaw.test.testconainers.api.auth.AuthApiTestResource;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
@@ -61,9 +61,9 @@ public class SessionResourceValidationTest {
 
   @Test
   public void get_sessions_should_be_under_cookie_auth() {
-    SsoTestSetupUtils.cookieExpect401(SessionResource.PATH, null);
-    SsoTestSetupUtils.cookieExpect401(SessionResource.PATH, "random");
-    SsoTestSetupUtils.cookieExpect401(SessionResource.PATH, SsoSession.newIdentifier());
+    cookieExpect401(SessionResource.PATH, null);
+    cookieExpect401(SessionResource.PATH, "random");
+    cookieExpect401(SessionResource.PATH, SsoSession.newIdentifier());
   }
 
   @Test
@@ -73,8 +73,8 @@ public class SessionResourceValidationTest {
         String.format(
             SessionResourceTest.SESSION_PAGE_PATH_TEMPLATE, UUID.randomUUID(), UUID.randomUUID());
 
-    SsoTestSetupUtils.cookieExpect401(path, null);
-    SsoTestSetupUtils.cookieExpect401(path, "random");
-    SsoTestSetupUtils.cookieExpect401(path, SsoSession.newIdentifier());
+    cookieExpect401(path, null);
+    cookieExpect401(path, "random");
+    cookieExpect401(path, SsoSession.newIdentifier());
   }
 }

--- a/backend/shared/rest/src/main/java/com/meemaw/shared/model/CanExpire.java
+++ b/backend/shared/rest/src/main/java/com/meemaw/shared/model/CanExpire.java
@@ -1,4 +1,4 @@
-package com.meemaw.auth.shared;
+package com.meemaw.shared.model;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/setup/SsoTestSetupUtils.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/setup/SsoTestSetupUtils.java
@@ -108,12 +108,25 @@ public final class SsoTestSetupUtils {
   }
 
   /**
-   * Log in with provided credentials.
+   * Log in with provided credentials. This method can only be used from auth-api as it uses an URL
+   * relative to the current environment for login endpoint. If you want to login from other module,
+   * use {@link #login(String email, String password, String baseURI)}.
    *
-   * @param baseURI auth api base uri
    * @param email address
    * @param password from the user
-   * @return String SessionID
+   * @return session id
+   */
+  public static String login(String email, String password) {
+    return login(email, password, null);
+  }
+
+  /**
+   * Log in with provided credentials.
+   *
+   * @param email address
+   * @param password from the user
+   * @param baseURI auth api base uri
+   * @return session id
    */
   public static String login(String email, String password, String baseURI) {
     String uri =
@@ -132,7 +145,7 @@ public final class SsoTestSetupUtils {
   }
 
   /**
-   * Log in with pre-created admin user.
+   * Log in with pre-created Insight admin user.
    *
    * @return session id
    */

--- a/backend/shared/testing-utils/src/main/java/com/meemaw/test/setup/SsoTestSetupUtils.java
+++ b/backend/shared/testing-utils/src/main/java/com/meemaw/test/setup/SsoTestSetupUtils.java
@@ -115,7 +115,7 @@ public final class SsoTestSetupUtils {
    * @param password from the user
    * @return String SessionID
    */
-  public static String login(String baseURI, String email, String password) {
+  public static String login(String email, String password, String baseURI) {
     String uri =
         String.join("/", Optional.ofNullable(baseURI).orElse("") + SsoResource.PATH, "login");
 
@@ -136,9 +136,9 @@ public final class SsoTestSetupUtils {
    *
    * @return session id
    */
-  public static String login() {
+  public static String loginWithInsightAdmin() {
     String authApiBaseURI = AuthApiTestExtension.getInstance().getBaseURI();
-    return login(authApiBaseURI, "admin@insight.io", "superDuperPassword123");
+    return login("admin@insight.io", "superDuperPassword123", authApiBaseURI);
   }
 
   /**

--- a/frontend/app/src/api/sso.ts
+++ b/frontend/app/src/api/sso.ts
@@ -22,6 +22,11 @@ const SsoApi = {
   logout: (baseURL = authApiBaseURL) => {
     return ky.post(`${baseURL}/v1/sso/logout`, { credentials: 'include' });
   },
+  logoutFromAllDevices: (baseURL = authApiBaseURL) => {
+    return ky.post(`${baseURL}/v1/sso/logout-from-all-devices`, {
+      credentials: 'include',
+    });
+  },
 };
 
 export default SsoApi;


### PR DESCRIPTION
- Implements `/v1/sso/logout-from-all-devices` endpoint
- Adds a reverse lookup Hazelcast map (userId -> sessions) for this to be possible
- This functionality will be reused in other places, e.g. when user deactivates/deletes his account