### PR TITLE
Multi arch builds 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,127 +11,45 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: sed -i "s/<GIT_COMMIT_SHA>/$(git rev-parse --short "$GITHUB_SHA")/g" backend/auth/auth-api/src/main/resources/application.properties
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: azure/docker-login@v1
         with:
-          name: ${{ env.REPOSITORY }}/auth-api
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: auth/auth-api/docker/Dockerfile.jvm
-          workdir: backend
-          tag_names: true
 
-  build-auth-api-postgres-migrations:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
         with:
-          name: ${{ env.REPOSITORY }}/auth-api-postgres-migrations
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: Dockerfile
-          workdir: backend/auth/auth-api/migrations/postgres/
-          tag_names: true
+          buildx-version: latest
+          qemu-version: latest
 
-  build-session-api:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: sed -i "s/<GIT_COMMIT_SHA>/$(git rev-parse --short "$GITHUB_SHA")/g" backend/session/session-api/src/main/resources/application.properties
-      - uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ env.REPOSITORY }}/session-api
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: session/session-api/docker/Dockerfile.jvm
-          workdir: backend
-          tag_names: true
+      - name: setup builder
+        run: |
+          docker buildx create --use --name=qemu --buildkitd-flags '--allow-insecure-entitlement network.host'
+          docker buildx inspect --bootstrap
 
-  build-session-api-postgres-migrations:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ env.REPOSITORY }}/session-api-postgres-migrations
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: Dockerfile
-          workdir: backend/session/session-api/migrations/postgres/
-          tag_names: true
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
 
-  build-session-api-elasticsearch-migrations:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ env.REPOSITORY }}/session-api-elasticsearch-migrations
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: Dockerfile
-          workdir: backend/session/session-api/migrations/elasticsearch/
-          tag_names: true
+      - name: Install skaffold
+        run: curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/
 
-  build-beacon-api:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - run: sed -i "s/<GIT_COMMIT_SHA>/$(git rev-parse --short "$GITHUB_SHA")/g" backend/beacon/beacon-api/src/main/resources/application.properties
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Build
+        run: |
+          mkdir out
+          skaffold build | sed 's/\(image:.*\)@.*$/\1/g' > out/manifest.yml
+      - name: Archive manifest
+        uses: actions/upload-artifact@v1
         with:
-          name: ${{ env.REPOSITORY }}/beacon-api
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: beacon/beacon-api/docker/Dockerfile.jvm
-          workdir: backend
-          tag_names: true
+          name: manifest
+          path: out/manifest.yml
 
-  build-search-indexer:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ env.REPOSITORY }}/search-indexer
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: events/search-indexer/docker/Dockerfile.jvm
-          workdir: backend
-          tag_names: true
-
-  build-frontend-app:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ env.REPOSITORY }}/frontend-app
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: frontend/app/docker/Dockerfile
-          tag_names: true
-          buildargs: session_api_client_base_url=https://session-api.dev.snuderls.eu,auth_api_client_base_url=https://auth-api.dev.snuderls.eu,auth_api_server_base_url=http://auth-api,try_app_base_url=https://try.dev.snuderls.eu,bootstrap_script=https://static.dev.snuderls.eu/b/development.insight.js
-
-  build-try-app:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: elgohr/Publish-Docker-Github-Action@master
-        with:
-          name: ${{ env.REPOSITORY }}/frontend-try
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: ${{ env.REGISTRY }}
-          dockerfile: frontend/try/docker/Dockerfile
-          tag_names: true
-          buildargs: auth_api_client_base_url=https://auth-api.dev.snuderls.eu,app_base_url=https://app.dev.snuderls.eu,bootstrap_script=https://static.dev.snuderls.eu/b/development.insight.js
+      # - name: Commit manifest
+      #   uses: cpina/github-action-push-to-another-repository@master
+      # - name: publish:starters
+      #   uses: johno/actions-push-subdirectories@master
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     args: out

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,12 +44,12 @@ jobs:
           name: manifest
           path: out/manifest.yml
 
-      # - name: Commit manifest
-      #   uses: cpina/github-action-push-to-another-repository@master
-      # - name: publish:starters
-      #   uses: johno/actions-push-subdirectories@master
-      #   env:
-      #     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     args: out
+# - name: Commit manifest
+#   uses: cpina/github-action-push-to-another-repository@master
+# - name: publish:starters
+#   uses: johno/actions-push-subdirectories@master
+#   env:
+#     API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+#     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#   with:
+#     args: out

--- a/backend/auth/auth-api/docker/Dockerfile.jvm
+++ b/backend/auth/auth-api/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM gradle:6.5.1-jdk14 as build
+FROM --platform=$BUILDPLATFORM gradle:6.5.1-jdk14 as build
 
 WORKDIR /backend
 
@@ -14,7 +14,7 @@ COPY shared/shared-sql/ /backend/shared/shared-sql/
 
 RUN gradle auth:auth-api:quarkusBuild --uber-jar
 
-FROM adoptopenjdk:14-jre-hotspot
+FROM --platform=$TARGETPLATFORM adoptopenjdk:14-jre-hotspot
 
 COPY --from=build /backend/auth/auth-api/build/auth-api-1.0-runner.jar /usr/app/service-runner.jar
 

--- a/backend/auth/auth-api/k8/base/deployment.yaml
+++ b/backend/auth/auth-api/k8/base/deployment.yaml
@@ -89,3 +89,8 @@ spec:
             timeoutSeconds: 1
             successThreshold: 1
             failureThreshold: 10
+      tolerations:
+        - key: "arm"
+          operator: "Equal"
+          value: "true"
+          effect: "NoExecute"

--- a/backend/beacon/beacon-api/docker/Dockerfile.jvm
+++ b/backend/beacon/beacon-api/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM gradle:6.5.1-jdk14 as build
+FROM --platform=$BUILDPLATFORM gradle:6.5.1-jdk14 as build
 
 WORKDIR /backend
 
@@ -14,7 +14,7 @@ COPY shared/rest-api/ /backend/shared/rest-api/
 
 RUN gradle beacon:beacon-api:quarkusBuild --uber-jar
 
-FROM adoptopenjdk:14-jre-hotspot
+FROM --platform=$TARGETPLATFORM adoptopenjdk:14-jre-hotspot
 
 COPY --from=build /backend/beacon/beacon-api/build/beacon-api-1.0-runner.jar /usr/app/service-runner.jar
 

--- a/backend/beacon/beacon-api/k8/base/deployment.yaml
+++ b/backend/beacon/beacon-api/k8/base/deployment.yaml
@@ -58,3 +58,8 @@ spec:
             timeoutSeconds: 1
             successThreshold: 1
             failureThreshold: 10
+      tolerations:
+        - key: "arm"
+          operator: "Equal"
+          value: "true"
+          effect: "NoExecute"

--- a/backend/custom_build.sh
+++ b/backend/custom_build.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -ex
+args=()  
+args+=('--tag' "$IMAGE")
+args+=('--builder' 'qemu')
+args+=('--network' 'host')
+if [ "$PUSH_IMAGE" = "true" ];
+then
+  args+=('--platform' 'linux/arm/v7,linux/amd64,linux/arm64')
+  args+=('-o' 'type=registry')
+else
+  args+=('--platform' 'linux/amd64')
+  args+=('-o' 'type=docker,dest=out')
+fi
+
+args+=('-f' "$1" "$BUILD_CONTEXT")
+docker buildx build "${args[@]}"
+
+if [ "$PUSH_IMAGE" = "false" ];
+then
+  docker load -i out
+  rm out
+fi

--- a/backend/events/search-indexer/docker/Dockerfile.jvm
+++ b/backend/events/search-indexer/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM gradle:6.5.1-jdk14 as build
+FROM --platform=$BUILDPLATFORM gradle:6.5.1-jdk14 as build
 
 COPY build.gradle lombok.config gradle.properties settings.gradle /backend/
 COPY shared/rest/ /backend/shared/rest/
@@ -7,9 +7,9 @@ COPY events/events-model/ /backend/events/events-model/
 COPY events/search-indexer/ /backend/events/search-indexer/
 WORKDIR /backend
 
-RUN gradle --no-daemon events:search-indexer:shadowJar
+RUN gradle --no-daemon events:search-indexer:shadowJar --stacktrace
 
-FROM adoptopenjdk:14-jre-hotspot
+FROM --platform=$TARGETPLATFORM adoptopenjdk:14-jre-hotspot
 
 COPY --from=build /backend/events/search-indexer/build/libs/search-indexer-1.0-all.jar /usr/app/search-indexer.jar
 

--- a/backend/events/search-indexer/k8/base/deployment.yaml
+++ b/backend/events/search-indexer/k8/base/deployment.yaml
@@ -35,3 +35,8 @@ spec:
             requests:
               cpu: 100m
               memory: 400Mi
+      tolerations:
+        - key: "arm"
+          operator: "Equal"
+          value: "true"
+          effect: "NoExecute"

--- a/backend/session/session-api/docker/Dockerfile.jvm
+++ b/backend/session/session-api/docker/Dockerfile.jvm
@@ -1,4 +1,4 @@
-FROM gradle:6.5.1-jdk14 as build
+FROM --platform=$BUILDPLATFORM gradle:6.5.1-jdk14 as build
 
 WORKDIR /backend
 
@@ -18,7 +18,7 @@ COPY shared/rest-api/ /backend/shared/rest-api/
 
 RUN gradle session:session-api:quarkusBuild --uber-jar
 
-FROM adoptopenjdk:14-jre-hotspot
+FROM --platform=$TARGETPLATFORM adoptopenjdk:14-jre-hotspot
 
 COPY --from=build /backend/session/session-api/build/session-api-1.0-runner.jar /usr/app/service-runner.jar
 

--- a/backend/session/session-api/k8/base/deployment.yaml
+++ b/backend/session/session-api/k8/base/deployment.yaml
@@ -70,3 +70,8 @@ spec:
             timeoutSeconds: 1
             successThreshold: 1
             failureThreshold: 10
+      tolerations:
+        - key: "arm"
+          operator: "Equal"
+          value: "true"
+          effect: "NoExecute"

--- a/infrastructure/k8/development/fluentbit.yaml
+++ b/infrastructure/k8/development/fluentbit.yaml
@@ -20,3 +20,10 @@ parsers:
       regex: '^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$'
       timeKey: time
       timeFormat: '%Y-%m-%dT%H:%M:%S.%L%z'
+
+tolerations:
+  - key: "arm"
+    operator: "Equal"
+    value: "true"
+    effect: "NoExecute"
+

--- a/infrastructure/k8/development/fluentbit.yaml
+++ b/infrastructure/k8/development/fluentbit.yaml
@@ -26,4 +26,3 @@ tolerations:
     operator: "Equal"
     value: "true"
     effect: "NoExecute"
-

--- a/infrastructure/k8/development/prometheus.yaml
+++ b/infrastructure/k8/development/prometheus.yaml
@@ -5,6 +5,12 @@ prometheus:
 alertmanager:
   alertmanagerSpec:
     replicas: 1
+nodeExporter:
+  tolerations:
+    - key: "arm"
+      operator: "Equal"
+      value: "true"
+      effect: "NoExecute"
 
 grafana:
   replicas: 1

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -25,12 +25,12 @@ patchesJson6902:
       kind: Job
       name: auth-api-postgres-migrations
     path: image-pull-secret.patch
-  - target:
-      group: batch
-      version: v1
-      kind: Job
-      name: auth-api-postgres-migrations
-    path: job-generate-name.patch
+  # - target:
+  #     group: batch
+  #     version: v1
+  #     kind: Job
+  #     name: auth-api-postgres-migrations
+  #   path: job-generate-name.patch
   - target:
       group: apps
       version: v1
@@ -43,12 +43,12 @@ patchesJson6902:
       kind: Job
       name: session-api-postgres-migrations
     path: image-pull-secret.patch
-  - target:
-      group: batch
-      version: v1
-      kind: Job
-      name: session-api-postgres-migrations
-    path: job-generate-name.patch
+  # - target:
+  #     group: batch
+  #     version: v1
+  #     kind: Job
+  #     name: session-api-postgres-migrations
+  #   path: job-generate-name.patch
   - target:
       group: apps
       version: v1

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: skaffold/v2beta5
+kind: Config
+metadata:
+  name: insight
+build:
+  local:
+    useBuildkit: true
+    concurrency: 3
+  tagPolicy:
+    gitCommit:
+      variant: CommitSha
+  artifacts:
+    - image: insightio/session-api
+      context: backend
+      custom:
+        buildCommand: ./custom_build.sh session/session-api/docker/Dockerfile.jvm
+    - image: insightio/auth-api
+      context: backend
+      custom:
+        buildCommand: ./custom_build.sh auth/auth-api/docker/Dockerfile.jvm
+    - image: insightio/auth-api-migrations
+      context: backend/auth/auth-api/migrations/postgres
+    - image: insightio/beacon-api
+      context: backend
+      custom:
+        buildCommand: ./custom_build.sh beacon/beacon-api/docker/Dockerfile.jvm
+    - image: insightio/frontend-app
+      context: .
+      docker:
+        dockerfile: frontend/app/docker/Dockerfile
+    - image: insightio/frontend-try
+      context: .
+      docker:
+        dockerfile: frontend/try/docker/Dockerfile
+    - image: insightio/search-indexer
+      context: backend
+      custom:
+        buildCommand: ./custom_build.sh events/search-indexer/docker/Dockerfile.jvm
+    - image: insightio/session-api-migrations
+      context: backend/session/session-api/migrations/postgres
+deploy:
+  kustomize:
+    paths:
+      - .
+profiles:
+  - name: push
+    build:
+      local:
+        push: true


### PR DESCRIPTION
This is experiment with multi arch builds and skaffold.

- java apps are build for multiple platforms. This requires some special work to have a single manifest contain multiple images (we use buildx for this).
- rpi node has a special taint, and we manually mark pods that support arm arhitecture, so only these can get shcheduled there
- this also experiments with usage of skaffold (tilt replacement + more deploy, ci/cd) support. Building, deploying and dev could be done done entirely through skaffold.

Some gotchas:
- skaffold can parallelize builds, but not with custom_builds at the moment (hopefully it will anyway support buildx sooner than later)
- skaffold deploy includes an image digest. This is great for immutability, but it actually does not work with multiarch images, so for now we can use the following sed command to remove it `(skaffold render | sed 's/\(image:.*\)@.*$/\1/g')`