### PR TITLE
fix(session-api): linking should be time bound

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,3 +7,16 @@
 ## Local development
 
 Look into [local-test-services](local-test-services/README.md).
+
+## Testing
+
+We are heavy believers in integration tests.
+Therefore, we heavily utilize [testcontainers](https://www.testcontainers.org/) for most of our tests.
+Because testcontainers work with [Docker](https://www.docker.com/), you need to have Docker installed on your computer for tests to pass.
+Moreover, we build containers for multi platform. This is currently not supported in default Docker, and requires [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/).
+You can enable BuiltKit by exporting these variables:
+
+```sh
+export COMPOSE_DOCKER_CLI_BUILD=1
+export DOCKER_BUILDKIT=1
+```

--- a/backend/session/session-api/src/main/java/com/meemaw/session/pages/service/PageService.java
+++ b/backend/session/session-api/src/main/java/com/meemaw/session/pages/service/PageService.java
@@ -48,6 +48,7 @@ public class PageService {
 
     // unrecognized device; start a new session
     if (!deviceId.equals(page.getDeviceId())) {
+      log.debug("Unrecognized device -- starting a new session");
       return createPageAndNewSession(pageId, deviceId, userAgent, ipAddress, page);
     }
 
@@ -58,13 +59,14 @@ public class PageService {
         .produceUni(
             maybeSessionId -> {
               if (maybeSessionId.isEmpty()) {
-                log.warn("Failed to link to an existing session");
+                log.debug("Failed to link to an existing session -- starting new session");
                 return createPageAndNewSession(pageId, deviceId, userAgent, ipAddress, page);
               }
               return pageDatasource.insertPage(pageId, maybeSessionId.get(), deviceId, page);
             });
   }
 
+  @Traced
   private Uni<PageIdentity> createPageAndNewSession(
       UUID pageId, UUID deviceId, String userAgent, String ipAddress, CreatePageDTO page) {
     UUID sessionId = UUID.randomUUID();

--- a/backend/session/session-api/src/main/java/com/meemaw/session/sessions/datasource/pg/PgSessionDatasource.java
+++ b/backend/session/session-api/src/main/java/com/meemaw/session/sessions/datasource/pg/PgSessionDatasource.java
@@ -10,6 +10,7 @@ import static com.meemaw.session.sessions.datasource.pg.SessionTable.IP_ADDRESS;
 import static com.meemaw.session.sessions.datasource.pg.SessionTable.ORGANIZATION_ID;
 import static com.meemaw.session.sessions.datasource.pg.SessionTable.TABLE;
 import static com.meemaw.session.sessions.datasource.pg.SessionTable.USER_AGENT;
+import static org.jooq.impl.DSL.condition;
 
 import com.meemaw.session.model.SessionDTO;
 import com.meemaw.session.sessions.datasource.SessionDatasource;
@@ -47,7 +48,13 @@ public class PgSessionDatasource implements SessionDatasource {
         SQLContext.POSTGRES
             .select(ID)
             .from(TABLE)
-            .where(ORGANIZATION_ID.eq(organizationId).and(DEVICE_ID.eq(deviceId)));
+            .where(
+                ORGANIZATION_ID
+                    .eq(organizationId)
+                    .and(DEVICE_ID.eq(deviceId))
+                    .and(condition("created_at > now() - INTERVAL '30 min'")))
+            .orderBy(CREATED_AT.desc())
+            .limit(1);
 
     return pgPool
         .preparedQuery(query.getSQL(ParamType.NAMED))


### PR DESCRIPTION
This condition got lost when refactoring from RAW_SQL to query builder. Added a test case that would have caught this.